### PR TITLE
Remade fixed layout as a dynamic layout

### DIFF
--- a/kdecoration/config/ui/breezeconfigurationui.ui
+++ b/kdecoration/config/ui/breezeconfigurationui.ui
@@ -37,7 +37,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_general">
       <attribute name="title">
        <string>General</string>
       </attribute>
@@ -351,7 +351,7 @@ Button icon st&amp;yle:   </string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_2">
+     <widget class="QWidget" name="tab_sizing_spacing">
       <property name="minimumSize">
        <size>
         <width>716</width>
@@ -361,615 +361,702 @@ Button icon st&amp;yle:   </string>
       <attribute name="title">
        <string>Sizing &amp;&amp; Spacing</string>
       </attribute>
-      <widget class="QComboBox" name="titleAlignment">
-       <property name="geometry">
-        <rect>
-         <x>160</x>
-         <y>10</y>
-         <width>149</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <item>
-        <property name="text">
-         <string>Left</string>
-        </property>
+      <layout class="QGridLayout" name="gridLayout_9">
+       <item row="0" column="1">
+        <spacer name="horizontalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item>
-        <property name="text">
-         <string>Centre</string>
-        </property>
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout_main">
+         <property name="spacing">
+          <number>20</number>
+         </property>
+         <item>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Tit&amp;le alignment:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>titleAlignment</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="titleAlignment">
+             <item>
+              <property name="text">
+               <string>Left</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Centre</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Centre (Full Width)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Right</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>B&amp;utton size:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>buttonSize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="buttonSize">
+             <item>
+              <property name="text">
+               <string>Tiny</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string comment="@item:inlistbox Button size:">Small</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string comment="@item:inlistbox Button size:">Medium</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string comment="@item:inlistbox Button size:">Large</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string comment="@item:inlistbox Button size:">Very Large</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="titlebarTopBottomMargins">
+             <property name="maximum">
+              <double>25.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QDoubleSpinBox" name="cornerRadius">
+             <property name="maximum">
+              <double>12.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>Titlebar top/bottom margins:</string>
+             </property>
+             <property name="buddy">
+              <cstring>titlebarTopBottomMargins</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_4">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Maximum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>200</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_11">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_14">
+             <property name="text">
+              <string>Corner radius: </string>
+             </property>
+             <property name="buddy">
+              <cstring>cornerRadius</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="1" column="6">
+            <widget class="QSpinBox" name="titlebarSideMargins_2">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="maximum">
+              <number>30</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <spacer name="horizontalSpacer_12">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="0">
+            <widget class="QSpinBox" name="titlebarSideMargins">
+             <property name="maximum">
+              <number>30</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Titlebar side margins:</string>
+             </property>
+             <property name="buddy">
+              <cstring>titlebarSideMargins</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Left-hand button spacing:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>buttonSpacingLeft</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <spacer name="horizontalSpacer_13">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="4">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>Right-hand button spacing:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>buttonSpacingRight</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QSpinBox" name="buttonSpacingLeft">
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="prefix">
+              <string/>
+             </property>
+             <property name="maximum">
+              <number>50</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="4">
+            <widget class="QSpinBox" name="buttonSpacingRight">
+             <property name="suffix">
+              <string/>
+             </property>
+             <property name="prefix">
+              <string/>
+             </property>
+             <property name="maximum">
+              <number>50</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="6">
+            <widget class="QLabel" name="label_11">
+             <property name="text">
+              <string>Titlebar side margins:</string>
+             </property>
+             <property name="buddy">
+              <cstring>titlebarSideMargins_2</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <spacer name="horizontalSpacer_14">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_7">
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="titlebarTopBottomMargins_2">
+             <property name="maximum">
+              <double>25.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_13">
+             <property name="text">
+              <string>Titlebar top/bottom margins:</string>
+             </property>
+             <property name="buddy">
+              <cstring>titlebarTopBottomMargins_2</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Maximum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>200</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="gridLayout_8">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Titlebar top/bottom margins for maximized windows:</string>
+             </property>
+             <property name="buddy">
+              <cstring>percentMaximizedTopBottomMargins</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="percentMaximizedTopBottomMargins">
+             <property name="suffix">
+              <string> %</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
-       <item>
-        <property name="text">
-         <string>Centre (Full Width)</string>
-        </property>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item>
-        <property name="text">
-         <string>Right</string>
-        </property>
-       </item>
-      </widget>
-      <widget class="QLabel" name="label_3">
-       <property name="geometry">
-        <rect>
-         <x>4</x>
-         <y>20</y>
-         <width>151</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Tit&amp;le alignment:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>titleAlignment</cstring>
-       </property>
-      </widget>
-      <widget class="QComboBox" name="buttonSize">
-       <property name="geometry">
-        <rect>
-         <x>160</x>
-         <y>50</y>
-         <width>130</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <item>
-        <property name="text">
-         <string>Tiny</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string comment="@item:inlistbox Button size:">Small</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string comment="@item:inlistbox Button size:">Medium</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string comment="@item:inlistbox Button size:">Large</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string comment="@item:inlistbox Button size:">Very Large</string>
-        </property>
-       </item>
-      </widget>
-      <widget class="QLabel" name="label_4">
-       <property name="geometry">
-        <rect>
-         <x>4</x>
-         <y>60</y>
-         <width>151</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>B&amp;utton size:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>buttonSize</cstring>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="buttonSpacingRight">
-       <property name="geometry">
-        <rect>
-         <x>430</x>
-         <y>210</y>
-         <width>51</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="suffix">
-        <string/>
-       </property>
-       <property name="prefix">
-        <string/>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_7">
-       <property name="geometry">
-        <rect>
-         <x>350</x>
-         <y>180</y>
-         <width>171</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Right-hand button spacing:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>buttonSpacingRight</cstring>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_8">
-       <property name="geometry">
-        <rect>
-         <x>160</x>
-         <y>180</y>
-         <width>161</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Left-hand button spacing:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>buttonSpacingLeft</cstring>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="buttonSpacingLeft">
-       <property name="geometry">
-        <rect>
-         <x>240</x>
-         <y>210</y>
-         <width>51</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="suffix">
-        <string/>
-       </property>
-       <property name="prefix">
-        <string/>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="titlebarSideMargins">
-       <property name="geometry">
-        <rect>
-         <x>50</x>
-         <y>210</y>
-         <width>52</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="maximum">
-        <number>30</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_10">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>190</y>
-         <width>131</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Titlebar side margins:</string>
-       </property>
-       <property name="buddy">
-        <cstring>titlebarSideMargins</cstring>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="titlebarSideMargins_2">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="geometry">
-        <rect>
-         <x>600</x>
-         <y>210</y>
-         <width>52</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="maximum">
-        <number>30</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_11">
-       <property name="geometry">
-        <rect>
-         <x>560</x>
-         <y>190</y>
-         <width>141</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Titlebar side margins:</string>
-       </property>
-       <property name="buddy">
-        <cstring>titlebarSideMargins_2</cstring>
-       </property>
-      </widget>
-      <widget class="QDoubleSpinBox" name="titlebarTopBottomMargins">
-       <property name="geometry">
-        <rect>
-         <x>340</x>
-         <y>140</y>
-         <width>61</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="maximum">
-        <double>25.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_12">
-       <property name="geometry">
-        <rect>
-         <x>220</x>
-         <y>120</y>
-         <width>181</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Titlebar top/bottom margins:</string>
-       </property>
-       <property name="buddy">
-        <cstring>titlebarTopBottomMargins</cstring>
-       </property>
-      </widget>
-      <widget class="QDoubleSpinBox" name="titlebarTopBottomMargins_2">
-       <property name="geometry">
-        <rect>
-         <x>340</x>
-         <y>290</y>
-         <width>61</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="maximum">
-        <double>25.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.050000000000000</double>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_13">
-       <property name="geometry">
-        <rect>
-         <x>220</x>
-         <y>270</y>
-         <width>181</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Titlebar top/bottom margins:</string>
-       </property>
-       <property name="buddy">
-        <cstring>titlebarTopBottomMargins_2</cstring>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_14">
-       <property name="geometry">
-        <rect>
-         <x>560</x>
-         <y>120</y>
-         <width>91</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Corner radius: </string>
-       </property>
-       <property name="buddy">
-        <cstring>cornerRadius</cstring>
-       </property>
-      </widget>
-      <widget class="QDoubleSpinBox" name="cornerRadius">
-       <property name="geometry">
-        <rect>
-         <x>590</x>
-         <y>140</y>
-         <width>61</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="maximum">
-        <double>12.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="percentMaximizedTopBottomMargins">
-       <property name="geometry">
-        <rect>
-         <x>480</x>
-         <y>360</y>
-         <width>71</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="suffix">
-        <string> %</string>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_15">
-       <property name="geometry">
-        <rect>
-         <x>150</x>
-         <y>370</y>
-         <width>331</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Titlebar top/bottom margins for maximized windows:</string>
-       </property>
-       <property name="buddy">
-        <cstring>percentMaximizedTopBottomMargins</cstring>
-       </property>
-      </widget>
+      </layout>
      </widget>
-     <widget class="QWidget" name="tab_5">
+     <widget class="QWidget" name="tab_transparency">
       <attribute name="title">
        <string>Transparency</string>
       </attribute>
-      <widget class="QLabel" name="_menuOpacityOpaqueLabel">
-       <property name="geometry">
-        <rect>
-         <x>6</x>
-         <y>6</y>
-         <width>181</width>
-         <height>31</height>
-        </rect>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Titlebar Opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuOpacityTransparentLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>60</y>
-         <width>74</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Transparent</string>
-       </property>
-      </widget>
-      <widget class="QSlider" name="activeTitlebarOpacity">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>80</y>
-         <width>561</width>
-         <height>23</height>
-        </rect>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="singleStep">
-        <number>1</number>
-       </property>
-       <property name="pageStep">
-        <number>10</number>
-       </property>
-       <property name="value">
-        <number>100</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="invertedAppearance">
-        <bool>false</bool>
-       </property>
-       <property name="invertedControls">
-        <bool>false</bool>
-       </property>
-       <property name="tickPosition">
-        <enum>QSlider::TicksBelow</enum>
-       </property>
-       <property name="tickInterval">
-        <number>10</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuGroupDescription">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>80</y>
-         <width>101</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Active window:</string>
-       </property>
-       <property name="buddy">
-        <cstring>activeTitlebarOpacity_2</cstring>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuOpacityTransparentLabel_2">
-       <property name="geometry">
-        <rect>
-         <x>650</x>
-         <y>60</y>
-         <width>51</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Opaque</string>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="activeTitlebarOpacity_2">
-       <property name="geometry">
-        <rect>
-         <x>370</x>
-         <y>50</y>
-         <width>71</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="suffix">
-        <string> %</string>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuGroupDescription_2">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>190</y>
-         <width>101</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Inactive window:</string>
-       </property>
-       <property name="buddy">
-        <cstring>inactiveTitlebarOpacity_2</cstring>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuOpacityTransparentLabel_3">
-       <property name="geometry">
-        <rect>
-         <x>650</x>
-         <y>170</y>
-         <width>51</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Opaque</string>
-       </property>
-      </widget>
-      <widget class="QSlider" name="inactiveTitlebarOpacity">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>190</y>
-         <width>561</width>
-         <height>23</height>
-        </rect>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="singleStep">
-        <number>1</number>
-       </property>
-       <property name="pageStep">
-        <number>10</number>
-       </property>
-       <property name="value">
-        <number>100</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="invertedAppearance">
-        <bool>false</bool>
-       </property>
-       <property name="invertedControls">
-        <bool>false</bool>
-       </property>
-       <property name="tickPosition">
-        <enum>QSlider::TicksBelow</enum>
-       </property>
-       <property name="tickInterval">
-        <number>10</number>
-       </property>
-      </widget>
-      <widget class="QLabel" name="_menuOpacityTransparentLabel_4">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>170</y>
-         <width>74</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Transparent</string>
-       </property>
-      </widget>
-      <widget class="QSpinBox" name="inactiveTitlebarOpacity_2">
-       <property name="geometry">
-        <rect>
-         <x>370</x>
-         <y>160</y>
-         <width>71</width>
-         <height>32</height>
-        </rect>
-       </property>
-       <property name="suffix">
-        <string> %</string>
-       </property>
-       <property name="maximum">
-        <number>100</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
-      <widget class="QCheckBox" name="opaqueMaximizedWindows">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>270</y>
-         <width>201</width>
-         <height>22</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Opaque maximized windows</string>
-       </property>
-      </widget>
+      <layout class="QGridLayout" name="gridLayout_13">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>20</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="_menuOpacityOpaqueLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Titlebar Opacity&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayout_2">
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="_menuOpacityTransparentLabel">
+               <property name="text">
+                <string>Transparent</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_9">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="activeTitlebarOpacity_2">
+               <property name="suffix">
+                <string> %</string>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_15">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="_menuOpacityTransparentLabel_2">
+               <property name="text">
+                <string>Opaque</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="_menuGroupDescription">
+             <property name="text">
+              <string>Active window:</string>
+             </property>
+             <property name="buddy">
+              <cstring>activeTitlebarOpacity_2</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSlider" name="activeTitlebarOpacity">
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="invertedAppearance">
+              <bool>false</bool>
+             </property>
+             <property name="invertedControls">
+              <bool>false</bool>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <spacer name="verticalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Maximum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="3" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="_menuOpacityTransparentLabel_4">
+               <property name="text">
+                <string>Transparent</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_16">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="inactiveTitlebarOpacity_2">
+               <property name="suffix">
+                <string> %</string>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_17">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="_menuOpacityTransparentLabel_3">
+               <property name="text">
+                <string>Opaque</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="_menuGroupDescription_2">
+             <property name="text">
+              <string>Inactive window:</string>
+             </property>
+             <property name="buddy">
+              <cstring>inactiveTitlebarOpacity_2</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QSlider" name="inactiveTitlebarOpacity">
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="singleStep">
+              <number>1</number>
+             </property>
+             <property name="pageStep">
+              <number>10</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="invertedAppearance">
+              <bool>false</bool>
+             </property>
+             <property name="invertedControls">
+              <bool>false</bool>
+             </property>
+             <property name="tickPosition">
+              <enum>QSlider::TicksBelow</enum>
+             </property>
+             <property name="tickInterval">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="opaqueMaximizedWindows">
+           <property name="text">
+            <string>Opaque maximized windows</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
-     <widget class="QWidget" name="tab_3">
+     <widget class="QWidget" name="tab_shadows">
       <attribute name="title">
        <string>Shadows</string>
       </attribute>
@@ -1109,7 +1196,7 @@ Button icon st&amp;yle:   </string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_4">
+     <widget class="QWidget" name="tab_overrides">
       <attribute name="title">
        <string>Window-Specific Overrides</string>
       </attribute>
@@ -1169,7 +1256,6 @@ Button icon st&amp;yle:   </string>
   <tabstop>activeTitlebarOpacity_2</tabstop>
   <tabstop>activeTitlebarOpacity</tabstop>
   <tabstop>inactiveTitlebarOpacity_2</tabstop>
-  <tabstop>inactiveTitlebarOpacity</tabstop>
   <tabstop>opaqueMaximizedWindows</tabstop>
   <tabstop>shadowSize</tabstop>
   <tabstop>shadowStrength</tabstop>


### PR DESCRIPTION
The layout for the tabs "Sizing & Spacing" and "Transparency" was not using layouts to responsively size widgets. This broke the layout with a font size any larger than 10, making the labels partially unreadable.

I have remade the layout for those two tabs to be similar to the other tabs (there are spacers on the right and bottom to keep the ui pushed to the top left when maximized), using dynamic layouts to respond to the user resizing the window. So, while the labels may still be cut off with a font size of 11, resizing the window (at run-time) by a few pixels will now let the user fix it.
On a side note, the original fixed layout had a couple alignment issues that were corrected in the process. Also, I decided not to indent the "Opaque maximized windows" checkbox, because it is not related to the section above it "Inactive window:". Therefore, this serves as a visual context separation.

Here I have built the new version to offer a before-and-after preview:

Original, font size 11
![classik1](https://user-images.githubusercontent.com/41875513/128789577-b2572046-d3df-403c-8330-cea067bc9ec2.png)

New layout, font size 11, window slightly widened (at run-time)
![classik1-1](https://user-images.githubusercontent.com/41875513/128789575-dd55ef54-fa21-4245-9396-1ba0aa68f0fe.png)

Original, font size 11
![classik2](https://user-images.githubusercontent.com/41875513/128789574-63ee071b-edd6-46a6-aa25-c902b701f4d0.png)

New layout, font size 11
![classik2-2](https://user-images.githubusercontent.com/41875513/128789573-fc5a272d-89b4-4a93-8c62-fd28064b506f.png)


If you would like me to tweak it further, I would be happy to accommodate your requests.