### PR TITLE
README.md: Add Gentoo Linux package installation instructions for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ##### Table of Contents
 [Overview](#overview)  
 [Installation](#installation)  
->[Pre-built packages](#prebuilt)  
->[Compile from source](#compile)  
+- [Gentoo Linux package](#gentoo-linux-package)
+- [Compile from source](#compile)  
 
 [System icon theme](#icons)  
 [Klassy Settings](#klassy-settings)  


### PR DESCRIPTION
Hi, I have packaged Klassy for Gentoo Linux and it is now available in the GURU repository which is a community repository of packages for Gentoo Linux.

I have changed the README to include installation instructions for Gentoo Linux. This package builds from the master branch.