### PR TITLE
README.md: Add Gentoo Linux package installation instructions for the plasma6.2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ Raw .rpm, .deb etc. binary packages are also available from the Open Build Servi
 There is a package available for Klassy in the [guru](https://github.com/gentoo/guru) repository.
 You can install Klassy on Gentoo Linux by following these steps.
 
+First, install the `eselect repository` module with:
+```
+sudo emerge -av app-eselect/eselect-repository
+```
+
 Enable the `guru` repository by executing:
 ```
 sudo eselect repository enable guru


### PR DESCRIPTION
Hi, I have packaged Klassy for Gentoo Linux and it is now available in the GURU repository which is a community repository of packages for Gentoo Linux.

I have changed the README to include installation instructions for Gentoo Linux. This package installs this release (https://github.com/paulmcauley/klassy/releases/tag/6.2.breeze6.2.1).
