### PR TITLE
Remove exact version number from Gentoo installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ sudo emaint sync -r guru
 
 Add the package keywords to `/etc/portage/package.accept_keywords`:
 ```
-echo "=gui-apps/klassy-6.5.1::guru ~amd64" | sudo tee /etc/portage/package.accept_keywords/klassy
+echo "gui-apps/klassy ~amd64" | sudo tee /etc/portage/package.accept_keywords/klassy
 ```
 
 Finally, compile & install the package with:
 ```
-sudo emerge -av =gui-apps/klassy-6.5.1::guru
+sudo emerge -av gui-apps/klassy
 ```
 
 &nbsp;


### PR DESCRIPTION
Portage automatically pulls in the latest version of the package when an exact version number is not specified.

This applies to everything except the master branch where you need to explicitly say you want the master branch version.